### PR TITLE
docs: add proposal implementation for the Run Command

### DIFF
--- a/design/run-process.md
+++ b/design/run-process.md
@@ -1,0 +1,62 @@
+# Proposal implementation for the Run Command
+
+## mf run
+
+Runs a workflow
+
+```text
+mf run [flags] WORKFLOWNAME
+```
+
+## Options
+
+```text
+    -h, --help   help for run
+    --dry-run    Dry run the workflow
+    --verbose    Verbose output
+```
+
+## Design V0
+
+Run the workflow in the following sequence of steps:
+
+```mermaid
+graph TD;
+    A[Parse the workflow file] --> B[Validate the Workflow Schema]
+    B --> C[Initialize Tools and Models]
+    C --> D[Run the Workflow]
+```
+
+For simplicity, workflow steps will be run in sequence. In the future, we can allow for more dynamic pipelines: see [Future improvements](#future-improvements).
+
+The implementation should create a pipeline to run the workflow. As we validate the workflow schema.
+
+### Pros
+
+By following this sequence, we ensure that the workflow is valid and that the tools and models are initialized correctly before running the workflow. This approach attempts to minimize the chances of errors during the workflow run, which could potentially result in partial or incorrect results. This step should be efficient as it is only static analysis of a relatively small file.
+
+### Cons
+
+The workflow may take longer to start running as it has to go through the validation and initialization steps. Before running any actions. 
+
+### Tasks
+
+- [x] Parse the workflow file (YAML)
+- [ ] Validate the Workflow Schema
+- [ ] Initialize Tools and Models
+- [ ] Create a pipeline to run the workflow
+
+### Considerations
+
+Should we prune any tools or models not used in the workflow? This could be a future optimization.
+
+
+### Future improvements
+
+- [ ] Allow for parallel execution of steps
+- [ ] Allow for looping
+- [ ] Allow for conditional execution of steps
+- [ ] Allow for dynamic generation of steps, tools, models, and actions
+- [ ] Allow for user input during the workflow run
+- [ ] Allow for user-defined functions to be used in the workflow
+

--- a/design/run-process.md
+++ b/design/run-process.md
@@ -12,7 +12,6 @@ mf run [flags] WORKFLOWNAME
 
 ```text
     -h, --help   help for run
-    --validate   Validate the workflow file
     --verbose    Verbose output
 ```
 

--- a/design/run-process.md
+++ b/design/run-process.md
@@ -12,19 +12,26 @@ mf run [flags] WORKFLOWNAME
 
 ```text
     -h, --help   help for run
-    --dry-run    Dry run the workflow
+    --validate   Validate the workflow file
     --verbose    Verbose output
 ```
 
-## Design V0
+## Design V0.1
 
 Run the workflow in the following sequence of steps:
 
 ```mermaid
 graph TD;
-    A[Parse the workflow file] --> B[Validate the Workflow Schema]
-    B --> C[Initialize dependencies]
-    C --> D[Run the Workflow]
+    A[Parse the workflow file]
+    subgraph B ["Create Pipeline"]
+        direction LR 
+        B1[Validate the workflow schema]
+        B2[Generate a workflow graph]
+        B1 --> B2 --> B1
+    end
+    C[Initialize dependencies]
+    D[Run the workflow]
+    A --> B --> C --> D
 ```
 
 For simplicity, workflow steps will be run in sequence. In the future, we can allow for more dynamic pipelines: see [Future improvements](#future-improvements).
@@ -48,15 +55,20 @@ The workflow may take longer to start running as it has to go through the valida
 
 ### Considerations
 
-Should we prune any tools or models not used in the workflow? This could be a future optimization.
+- Can users re-run failed steps? This could be a future feature.
+- What happens if the user tries to interpret in the middle of a workflow run?
+
+
 
 
 ### Future improvements
 
+- [ ] Containerize workflows to avoid modifying the user's environment or system, and make it easier to throw away the environment after or during the workflow run
 - [ ] Allow for parallel execution of steps
 - [ ] Allow for looping
 - [ ] Allow for conditional execution of steps
 - [ ] Allow for dynamic generation of steps, tools, models, and actions
 - [ ] Allow for user input during the workflow run
 - [ ] Allow for user-defined functions to be used in the workflow
+- [ ] Prune the workflow graph to remove unnecessary items
 

--- a/design/run-process.md
+++ b/design/run-process.md
@@ -23,7 +23,7 @@ Run the workflow in the following sequence of steps:
 ```mermaid
 graph TD;
     A[Parse the workflow file] --> B[Validate the Workflow Schema]
-    B --> C[Initialize Tools and Models]
+    B --> C[Initialize dependencies]
     C --> D[Run the Workflow]
 ```
 


### PR DESCRIPTION
This pull request introduces a proposal implementation for the Run Command in the `design/run-process.md` file. The changes include a detailed design for running workflows with `mf run`, outlining the options, sequence of steps, and future improvements.

Key changes:

* **New Command Proposal**:
  * `mf run` command to run workflows with options for help, dry run, and verbose output.

* **Design Sequence**:
  * Workflow steps are parsed, validated, tools and models initialized, and then the workflow is run in sequence.

* **Pros and Cons**:
  * Pros: Ensures workflow validity and correct initialization of tools and models.
  * Cons: Potential delay in starting the workflow due to validation and initialization steps.

* **Tasks and Future Improvements**:
  * Tasks include parsing the workflow file, validating the schema, initializing tools and models, and creating a pipeline.
  * Future improvements suggest parallel execution, looping, conditional steps, dynamic generation, user input, and user-defined functions.